### PR TITLE
feat: use @scure/sr25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ These libraries provide robust support for various signature schemes, are optimi
 ## Libraries
 
 - `@polkadot-labs/hdkd` is a Hierarchical Deterministic (HD) account derivation library compatible with the Polkadot and Substrate ecosystems. It supports the sr25519, ed25519, and ecdsa signature schemes, providing a comprehensive solution for HD account derivation.
-- `@polkadot-labs/hdkd-helpers` is a pure JavaScript library providing utility functions for three signature schemes: sr25519, ed25519, and ecdsa. This library is designed to assist with Hierarchical Deterministic Key Derivation (HDKD) in the Polkadot ecosystem. It is built on top of `@noble/hashes`, `@noble/curves`, and `micro-sr25519`.
+- `@polkadot-labs/hdkd-helpers` is a pure JavaScript library providing utility functions for three signature schemes: sr25519, ed25519, and ecdsa. This library is designed to assist with Hierarchical Deterministic Key Derivation (HDKD) in the Polkadot ecosystem. It is built on top of `@noble/hashes`, `@noble/curves`, and `@scure/sr25519`.
 - `@polkadot-labs/schnorrkel-wasm` is a JavaScript WebAssembly (WASM) wrapper for the Schnorrkel crate. This package provides a convenient interface for using Schnorrkel's cryptographic functions in JavaScript applications.
 
 ## Usage

--- a/packages/hdkd-helpers/README.md
+++ b/packages/hdkd-helpers/README.md
@@ -3,7 +3,7 @@
 `@polkadot-labs/hdkd-helpers` is a pure JavaScript library providing utility functions for three signature schemes: sr25519, ed25519, and ecdsa.
 This library is designed to assist with Hierarchical Deterministic Key Derivation (HDKD) in the Polkadot ecosystem.
 Additionally, it includes utilities for deriving HD accounts with hard and soft derivation, creating ss58 addresses, and deriving private keys through bip39.
-It is built on top of `@noble/hashes`, `@noble/curves`, and `micro-sr25519`.
+It is built on top of `@noble/hashes`, `@noble/curves`, and `@scure/sr25519`.
 
 ## Features
 
@@ -33,7 +33,7 @@ import {
   entropyToMiniSecret,
   mnemonicToEntropy,
 } from "@polkadot-labs/hdkd-helpers"
-import { secretFromSeed } from "micro-sr25519"
+import { secretFromSeed } from "@scure/sr25519"
 
 const entropy = mnemonicToEntropy(DEV_PHRASE)
 const miniSecret = entropyToMiniSecret(entropy)

--- a/packages/hdkd-helpers/package.json
+++ b/packages/hdkd-helpers/package.json
@@ -47,7 +47,7 @@
     "@noble/curves": "^1.9.2",
     "@noble/hashes": "^1.8.0",
     "@scure/base": "^1.2.6",
-    "micro-sr25519": "^0.1.3",
+    "@scure/sr25519": "^0.2.0",
     "scale-ts": "^1.6.1"
   }
 }

--- a/packages/hdkd-helpers/src/sr25519.ts
+++ b/packages/hdkd-helpers/src/sr25519.ts
@@ -1,4 +1,4 @@
-import { getPublicKey, sign, verify } from "micro-sr25519"
+import { getPublicKey, sign, verify } from "@scure/sr25519"
 import { ensureBytes } from "./utils"
 
 import type { Curve } from "./types"

--- a/packages/hdkd-helpers/src/sr25519Derive.ts
+++ b/packages/hdkd-helpers/src/sr25519Derive.ts
@@ -1,15 +1,11 @@
-import { randomBytes } from "@noble/hashes/utils"
-import { HDKD, getPublicKey, secretFromSeed } from "micro-sr25519"
+import { HDKD, getPublicKey, secretFromSeed } from "@scure/sr25519"
 import type { DeriveKeyPairFn } from "./internal/types"
 
 export const sr25519Derive: DeriveKeyPairFn = (seed, curve, derivations) => {
-  const privateKey = derivations.reduce(
-    (secretKey, [type, chainCode]) =>
-      type === "hard"
-        ? HDKD.secretHard(secretKey, chainCode)
-        : HDKD.secretSoft(secretKey, chainCode, randomBytes),
-    secretFromSeed(seed),
-  )
+  const privateKey = derivations.reduce((secretKey, [type, chainCode]) => {
+    const deriveFn = type === "hard" ? HDKD.secretHard : HDKD.secretSoft
+    return deriveFn(secretKey, chainCode)
+  }, secretFromSeed(seed))
   const publicKey = getPublicKey(privateKey)
   return {
     publicKey,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,9 @@ importers:
       '@scure/base':
         specifier: ^1.2.6
         version: 1.2.6
-      micro-sr25519:
-        specifier: ^0.1.3
-        version: 0.1.3
+      '@scure/sr25519':
+        specifier: ^0.2.0
+        version: 0.2.0
       scale-ts:
         specifier: ^1.6.1
         version: 1.6.1
@@ -446,16 +446,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@noble/curves@1.8.2':
-    resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
-    engines: {node: ^14.21.3 || >=16}
-
   '@noble/curves@1.9.2':
     resolution: {integrity: sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==}
-    engines: {node: ^14.21.3 || >=16}
-
-  '@noble/hashes@1.7.2':
-    resolution: {integrity: sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.8.0':
@@ -683,6 +675,9 @@ packages:
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/sr25519@0.2.0':
+    resolution: {integrity: sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -1409,9 +1404,6 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  micro-sr25519@0.1.3:
-    resolution: {integrity: sha512-Tw1I3Yjq9XySsU3hsgPVkQTG3NIje070VUWtT4tb9d1tVwQqpCIBH4SM5h4Mxp2Ua4PUyPsot2F40eyJ0QnzTg==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2161,15 +2153,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@noble/curves@1.8.2':
-    dependencies:
-      '@noble/hashes': 1.7.2
-
   '@noble/curves@1.9.2':
     dependencies:
       '@noble/hashes': 1.8.0
-
-  '@noble/hashes@1.7.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -2311,6 +2297,11 @@ snapshots:
     optional: true
 
   '@scure/base@1.2.6': {}
+
+  '@scure/sr25519@0.2.0':
+    dependencies:
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -3058,11 +3049,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   merge2@1.4.1: {}
-
-  micro-sr25519@0.1.3:
-    dependencies:
-      '@noble/curves': 1.8.2
-      '@noble/hashes': 1.7.2
 
   micromatch@4.0.8:
     dependencies:


### PR DESCRIPTION
Use audited `@scure/sr25519` (renamed from `micro-sr25519`)

https://github.com/paulmillr/scure-sr25519/releases/tag/0.2.0