### PR TITLE
fix(schnorrkel-wasm): esm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,26 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('packages/schnorrkel-wasm/rust/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - run: which wasm-pack || cargo install wasm-pack
+      - name: Ensure wasm-pack version
+        run: |
+          set -e
+
+          REQUIRED_VERSION="0.14.0"
+
+          if command -v wasm-pack >/dev/null 2>&1; then
+            INSTALLED_VERSION=$(wasm-pack --version | awk '{print $2}')
+            if [ "$INSTALLED_VERSION" = "$REQUIRED_VERSION" ]; then
+              echo "wasm-pack $REQUIRED_VERSION already installed"
+              exit 0
+            else
+              echo "Found wasm-pack $INSTALLED_VERSION, but need $REQUIRED_VERSION"
+            fi
+          else
+            echo "wasm-pack not installed"
+          fi
+
+          echo "Installing wasm-pack $REQUIRED_VERSION..."
+          cargo install wasm-pack --version $REQUIRED_VERSION --force
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:

--- a/packages/schnorrkel-wasm/scripts/patch.mjs
+++ b/packages/schnorrkel-wasm/scripts/patch.mjs
@@ -9,15 +9,10 @@ const name = cargoPackageName.replace(/-/g, "_")
 const content = await readFile(`./dist/nodejs/${name}.js`, "utf8")
 
 const patched = content
-  // use global TextDecoder TextEncoder
-  .replace("require(`util`)", "globalThis")
-  // attach to `imports` instead of module.exports
-  .replace("= module.exports", "= imports")
-  .replace(/\nmodule\.exports\.(.*?)\s+/g, "\nexport const $1 = imports.$1 ")
-  .replace(/$/, "export default imports")
+  .replace(/exports\.(\w+)\s*=\s*\1\s*;/g, "export { $1 };")
   // inline bytes Uint8Array
   .replace(
-    /\nconst path.*\nconst bytes.*\n/,
+    /\nconst wasmPath.*\nconst wasmBytes.*\n/,
     `
 var __toBinary = /* @__PURE__ */ (() => {
   var table = new Uint8Array(128);
@@ -36,7 +31,7 @@ var __toBinary = /* @__PURE__ */ (() => {
   };
 })();
 
-const bytes = __toBinary(${JSON.stringify(
+const wasmBytes = __toBinary(${JSON.stringify(
       await readFile(`./dist/nodejs/${name}_bg.wasm`, "base64"),
     )});
 `,


### PR DESCRIPTION
This pull request focuses on improving the build and packaging process for the `schnorrkel-wasm` package, with updates to both the CI workflow and the patching script. The main goals are to ensure consistent tooling versions and to refine the way the JavaScript output is patched for module exports and WASM byte handling.

**Build and CI improvements:**

* Updated the CI workflow in `.github/workflows/ci.yml` to ensure that the exact required version (`0.14.0`) of `wasm-pack` is installed, replacing the previous check that only installed it if missing. This prevents version mismatches in CI runs.

**Packaging and output patching:**

* Refined the patching script in `packages/schnorrkel-wasm/scripts/patch.mjs` to:
  - Replace CommonJS-style `exports.foo = foo;` assignments with ES module `export { foo };` syntax for cleaner exports.
  - Update the WASM byte inlining logic to use `wasmPath` and `wasmBytes` instead of the previous `path` and `bytes` variables, improving clarity and consistency. [[1]](diffhunk://#diff-491c93e016a80008b1cd7ac2da38e8a05ff25f856de930f3b8b09d0fa7bc906aL12-R15) [[2]](diffhunk://#diff-491c93e016a80008b1cd7ac2da38e8a05ff25f856de930f3b8b09d0fa7bc906aL39-R34)