### PR TITLE
feat(schnorrkel-wasm): add Substrate SecretKey::from_bytes exports

### DIFF
--- a/packages/schnorrkel-wasm/README.md
+++ b/packages/schnorrkel-wasm/README.md
@@ -41,6 +41,25 @@ const isValid = sr25519_verify(publicKey, message, signature)
 console.log("Is valid:", isValid)
 ```
 
+### Substrate 64-byte secrets
+
+`sr25519_pubkey` / `sr25519_sign` use `SecretKey::from_ed25519_bytes` (32-byte ed25519 secrets from seed derivation).
+
+For a **64-byte Substrate secret** (e.g. 32-byte private key + 32-byte nonce, as used by Substrate SDK slot accounts), use:
+
+```ts
+import {
+  sr25519_pubkey_from_secret_bytes,
+  sr25519_sign_from_secret_bytes,
+  sr25519_verify,
+} from "@polkadot-labs/schnorrkel-wasm"
+
+const secret = new Uint8Array(64) // slot / Substrate SecretKey bytes
+const publicKey = sr25519_pubkey_from_secret_bytes(secret)
+const signature = sr25519_sign_from_secret_bytes(publicKey, secret, message)
+const isValid = sr25519_verify(publicKey, message, signature)
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](../../LICENSE) file for details.

--- a/packages/schnorrkel-wasm/rust/src/lib.rs
+++ b/packages/schnorrkel-wasm/rust/src/lib.rs
@@ -37,8 +37,27 @@ pub fn sr25519_pubkey(secret: &[u8]) -> Vec<u8> {
         .to_public()
         .to_bytes()
         .to_vec()
-    // let secret = SecretKey::from_bytes(secret).expect("Invalid secret");
-    // secret.to_public().to_bytes().to_vec()
+}
+
+fn secret_from_substrate_bytes(secret: &[u8]) -> SecretKey {
+    SecretKey::from_bytes(secret).expect("Invalid secret (expected 64-byte Substrate secret)")
+}
+
+/// Derive a public key from a 64-byte Substrate sr25519 secret (`SecretKey::from_bytes`).
+#[wasm_bindgen]
+pub fn sr25519_pubkey_from_secret_bytes(secret: &[u8]) -> Vec<u8> {
+    secret_from_substrate_bytes(secret)
+        .to_public()
+        .to_bytes()
+        .to_vec()
+}
+
+/// Sign with a 64-byte Substrate sr25519 secret (`SecretKey::from_bytes`).
+#[wasm_bindgen]
+pub fn sr25519_sign_from_secret_bytes(pubkey: &[u8], secret: &[u8], msg: &[u8]) -> Vec<u8> {
+    let pubkey = PublicKey::from_bytes(pubkey).expect("Invalid pubkey");
+    let secret = secret_from_substrate_bytes(secret);
+    secret.sign_simple(CTX, msg, &pubkey).to_bytes().to_vec()
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Adds WASM exports for 64-byte Substrate sr25519 secrets (SecretKey::from_bytes)