### PR TITLE
chore: bump pnpm from 10.20.0 to 11.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "*.md": "prettier --write",
     "*.{js,jsx,ts,tsx,json}": "biome check --write --no-errors-on-unmatched"
   },
-  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd"
+  "packageManager": "pnpm@11.15.0+sha512.266f8957a30d2be6e9468e5e66bcdedd35a794175f71b067ba8504d686cce1d0c0f429b33c323c3c569ad4891e667574a49ff71d1b89a22cc66f13c65818c578"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,6 @@ packages:
   - packages/*
   - examples/*
 
-onlyBuiltDependencies:
-  - '@swc/core'
-  - esbuild
+allowBuilds:
+  "@swc/core": true
+  esbuild: true


### PR DESCRIPTION
This pull request updates package management and build configuration to improve dependency handling and ensure compatibility with newer tooling. The most important changes are:

**Package management updates:**
* Upgraded the `pnpm` package manager version from `10.20.0` to `11.15.0` in `package.json`, ensuring compatibility with the latest features and bug fixes.

**Build configuration changes:**
* Replaced the deprecated `onlyBuiltDependencies` option with the new `allowBuilds` configuration in `pnpm-workspace.yaml`, explicitly allowing builds for `@swc/core` and `esbuild`.